### PR TITLE
Output filename with PST

### DIFF
--- a/scripts/donor_history.sh
+++ b/scripts/donor_history.sh
@@ -5,7 +5,8 @@ set -o nounset
 set -o pipefail
 #set -o xtrace
 
-SCRATCH_FILE="scratch/donorhistory_`date -u +%FT%H-%M-%SZ`.csv"
+# Need to output time as PST because that's what the SFMC account setting is
+SCRATCH_FILE="scratch/donorhistory_`TZ=America/Los_Angeles date +%FT%H-%M-%S`.csv"
 SFTP_BATCH_FILE=`cat <<EOF
 cd FoundationDonors/
 ls


### PR DESCRIPTION
We have a bug with the SFMC automation where it doesn't load the donor history file because UTC is ahead of PST, and it'll refuse to load the file that comes from the future
